### PR TITLE
Fix invalid using directive in plugin

### DIFF
--- a/ModuleBatteries/Plugins.cs
+++ b/ModuleBatteries/Plugins.cs
@@ -5,7 +5,6 @@ using ModuleBatteries.Items;
 using ModuleBatteries.Patches;
 using UWE;
 using static ModuleBatteries.utilities.GameObjectExtensions;
-using static ModuleBatteries.text.MonitorOverlayManager;
 
 namespace ModuleBatteries
 {


### PR DESCRIPTION
## Summary
- remove reference to non-existent `MonitorOverlayManager` to fix build

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687527bb8540832eb954b7e53379da6b